### PR TITLE
Listing project members

### DIFF
--- a/lib/clients/client.ex
+++ b/lib/clients/client.ex
@@ -7,7 +7,7 @@ defmodule GlassFactoryApi.Clients.Client do
   @type t() :: %Client{
           id: String.t(),
           name: String.t(),
-          archived_at: String.t(),
+          archived_at: String.t() | nil,
           owner_id: String.t(),
           office_id: String.t()
         }
@@ -28,6 +28,7 @@ defmodule GlassFactoryApi.Clients.Client do
         office_id: 789
       }
   """
+  @spec to_struct(map) :: t
   def to_struct(attrs) do
     %Client{
       id: attrs["id"],

--- a/lib/members/member.ex
+++ b/lib/members/member.ex
@@ -3,9 +3,7 @@ defmodule GlassFactoryApi.Members.Member do
   Defines the Member of organization.
   """
 
-  alias GlassFactoryApi.Members.Member
-
-  @type t() :: %Member{
+  @type t() :: %__MODULE__{
           name: String.t(),
           email: String.t(),
           id: integer(),
@@ -33,9 +31,9 @@ defmodule GlassFactoryApi.Members.Member do
         joined_at: "2019-01-01"
       }
   """
-  @spec to_struct(map()) :: Member.t()
+  @spec to_struct(map()) :: __MODULE__.t()
   def to_struct(attrs) do
-    %Member{
+    %__MODULE__{
       name: attrs["name"],
       id: attrs["id"],
       email: attrs["email"],

--- a/lib/projects/project.ex
+++ b/lib/projects/project.ex
@@ -57,6 +57,7 @@ defmodule GlassFactoryApi.Projects.Project do
          archived: false...
       }
   """
+  @spec to_struct(map()) :: Project.t()
   def to_struct(attrs) do
     %Project{
       archived: attrs["archived"],

--- a/lib/projects/project_member.ex
+++ b/lib/projects/project_member.ex
@@ -1,0 +1,38 @@
+defmodule GlassFactoryApi.Projects.ProjectMember do
+  @moduledoc """
+  Defines a Member of a Project.
+  """
+
+  @type t() :: %__MODULE__{
+          id: String.t(),
+          user_id: String.t(),
+          project_id: String.t()
+        }
+
+  defstruct [
+    :id,
+    :user_id,
+    :project_id
+  ]
+
+  @doc """
+  Parser a map into a ProjectMember struct.
+
+  ## Examples
+
+      iex> GlassFactoryApi.Projects.ProjectMember.to_struct(%{"id" => 1, "user_id" => 123, "project_id" => 456})
+      %ProjectMember{
+        id: "1",
+        user_id: "123",
+        project_id: "456"
+      }
+  """
+  @spec to_struct(map()) :: __MODULE__.t()
+  def to_struct(attrs) do
+    %__MODULE__{
+      id: attrs["id"],
+      user_id: attrs["user_id"],
+      project_id: attrs["project_id"]
+    }
+  end
+end

--- a/test/fixtures/project_members.ex
+++ b/test/fixtures/project_members.ex
@@ -1,0 +1,13 @@
+defmodule GlassFactoryApi.Fixtures.ProjectMembers do
+  def list do
+    ~s<
+    [
+      {
+        "id": "200300",
+        "user_id": "3299",
+        "project_id": "123"
+      }
+    ]
+    >
+  end
+end

--- a/test/projects/project_member_test.exs
+++ b/test/projects/project_member_test.exs
@@ -1,0 +1,17 @@
+defmodule GlassFactoryApi.Projects.ProjectMemberTest do
+  use ExUnit.Case, async: false
+
+  alias GlassFactoryApi.Projects.ProjectMember
+
+  describe "to_struct/1" do
+    test "parses a map to a ProjectMember" do
+      attrs = %{"id" => "1", "user_id" => "123", "project_id" => "456"}
+
+      assert %ProjectMember{
+               id: "1",
+               user_id: "123",
+               project_id: "456"
+             } == ProjectMember.to_struct(attrs)
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

Add resources to get the `Members` of a `Project`


### Comments

- The GlassFactory API returns just a list with the ID of members and project, so at this moment we will keep it simple (KISS principle) and return just what the API gives us. In another moment we can discuss if it worth create another method or configuration that expands the entities.

- There was some inconsistency in some methods with missing [typespecs](https://hexdocs.pm/elixir/typespecs.html), not handling errors and not returning what it supposed to return, I took this PR as opportunity to fix them too. 


Closes #22 