### PR TITLE
Normalize ApiClient result.

### DIFF
--- a/lib/api_client.ex
+++ b/lib/api_client.ex
@@ -18,7 +18,12 @@ defmodule GlassFactoryApi.ApiClient do
   def get(resource, configuration) do
     config = Configuration.build(configuration)
 
-    Tesla.get(tesla_client(config), resource)
+    with {:ok, result} <- Tesla.get(tesla_client(config), resource) do
+      {:ok, result}
+    else
+      {:error, error} when is_atom(error) -> {:error, Atom.to_string(error)}
+      {:error, error} -> {:error, error}
+    end
   end
 
   defp tesla_client(configuration) do

--- a/lib/projects.ex
+++ b/lib/projects.ex
@@ -29,7 +29,6 @@ defmodule GlassFactoryApi.Projects do
   def list_projects(config \\ %{}) do
     case ApiClient.get("projects", config) do
       {:ok, %{status: 200, body: body}} -> {:ok, Enum.map(body, &Project.to_struct(&1))}
-      {:error, error} when is_atom(error) -> {:error, Atom.to_string(error)}
       {:error, error} -> {:error, error}
     end
   end
@@ -84,7 +83,6 @@ defmodule GlassFactoryApi.Projects do
       {:ok, %{status: 200, body: body}} -> {:ok, Project.to_struct(body)}
       {:ok, %{status: 404}} -> {:error, "Can't find a project with ID #{project_id}"}
       {:ok, %{body: body}} -> {:error, body}
-      {:error, error} when is_atom(error) -> Atom.to_string(error)
       {:error, error} -> error
     end
   end
@@ -92,7 +90,7 @@ defmodule GlassFactoryApi.Projects do
   @doc """
   Returns the project given the id or raises an error if something went wrong.
 
-  Same of `get_project\2` but raises instead of returning a tuple with `:error` 
+  Same of `get_project\2` but raises instead of returning a tuple with `:error`
 
   ## Examples
 

--- a/test/api_client_test.exs
+++ b/test/api_client_test.exs
@@ -31,5 +31,11 @@ defmodule GlassFactoryApi.ApiClientTest do
       assert %{status: 200, body: body, headers: headers} = response
       assert body == %{"description" => "some foo json"}
     end
+
+    test "returns the error when connection fail", %{bypass: bypass, config: config} do
+      Bypass.down(bypass)
+
+      assert {:error, "econnrefused"} = ApiClient.get("users", config)
+    end
   end
 end


### PR DESCRIPTION
Resolves #26 

We've checked that sometimes ApiClient can return a tuple of atoms as a result. An example of this is when the connection is refused:
```elixir
{:error, :econrefused}
```
We need to make sure that the result provided by ApiClient is always `{atom(), String.t()}`