### PR TITLE
Ignore .tool-versions file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ glass_factory_api-*.tar
 
 # Ignore secret config files
 /config/*.secret.exs
+
+# Ignore tool-versions file for asdf
+.tool-versions


### PR DESCRIPTION
## Motivation

The tool-versions file is a config file for ASDF, but the file isn't necessary for the project.

## Solution Proposed

Add .tool-versions file to .gitignore
