### PR TITLE
Add avatar property to members

### DIFF
--- a/lib/members.ex
+++ b/lib/members.ex
@@ -31,7 +31,7 @@ defmodule GlassFactoryApi.Members do
   @spec list_members(map()) :: {atom(), list(Member.t()) | String.t()}
   def list_members(config \\ %{}) do
     with {:ok, %{status: 200, body: body}} <- ApiClient.get("members", config) do
-      {:ok, Enum.map(body, &Member.to_struct(&1))}
+      {:ok, Enum.map(body, &Member.to_struct(&1, config))}
     else
       {:error, error} -> {:error, error}
     end
@@ -91,7 +91,7 @@ defmodule GlassFactoryApi.Members do
   @spec get_member(String.t(), map()) :: {atom(), Member.t() | String.t()}
   def get_member(member_id, config \\ %{}) do
     with {:ok, %{status: 200, body: body}} <- ApiClient.get("members/#{member_id}", config) do
-      {:ok, Member.to_struct(body)}
+      {:ok, Member.to_struct(body, config)}
     else
       {:ok, %{status: 404}} -> {:error, "Can't find a member with ID #{member_id}"}
       {:error, error} -> {:error, error}
@@ -151,7 +151,7 @@ defmodule GlassFactoryApi.Members do
   @spec list_active_members(map()) :: {:ok, list(Member)} | {:error, any}
   def list_active_members(config \\ %{}) do
     with {:ok, %{status: 200, body: body}} <- ApiClient.get("members/active", config) do
-      {:ok, Enum.map(body, &Member.to_struct(&1))}
+      {:ok, Enum.map(body, &Member.to_struct(&1, config))}
     else
       {:error, error} -> {:error, error}
     end

--- a/lib/members/avatar.ex
+++ b/lib/members/avatar.ex
@@ -1,0 +1,26 @@
+defmodule GlassFactoryApi.Members.Avatar do
+  @type t :: %__MODULE__{
+          url: String.t(),
+          medium: %{url: String.t()},
+          small: %{url: String.t()},
+          thumb: %{url: String.t()}
+        }
+
+  defstruct [:url, :medium, :small, :thumb]
+
+  @spec to_struct(map()) :: __MODULE__.t()
+  def to_struct(attrs) do
+    %__MODULE__{
+      url: Map.fetch!(attrs, "url"),
+      medium: %{
+        url: attrs["medium"]["url"]
+      },
+      small: %{
+        url: attrs["small"]["url"]
+      },
+      thumb: %{
+        url: attrs["thumb"]["url"]
+      }
+    }
+  end
+end

--- a/lib/members/avatar.ex
+++ b/lib/members/avatar.ex
@@ -8,7 +8,7 @@ defmodule GlassFactoryApi.Members.Avatar do
 
   defstruct [:url, :medium, :small, :thumb]
 
-  @spec to_struct(map()) :: __MODULE__.t()
+  @spec to_struct(map()) :: t()
   def to_struct(attrs) do
     %__MODULE__{
       url: Map.fetch!(attrs, "url"),

--- a/lib/members/avatar.ex
+++ b/lib/members/avatar.ex
@@ -1,4 +1,6 @@
 defmodule GlassFactoryApi.Members.Avatar do
+  alias GlassFactoryApi.Configuration
+
   @type t :: %__MODULE__{
           url: String.t(),
           medium: %{url: String.t()},
@@ -8,19 +10,36 @@ defmodule GlassFactoryApi.Members.Avatar do
 
   defstruct [:url, :medium, :small, :thumb]
 
-  @spec to_struct(map()) :: t()
-  def to_struct(attrs) do
+  @spec to_struct(map(), map()) :: t()
+  def to_struct(attrs, config) do
     %__MODULE__{
-      url: Map.fetch!(attrs, "url"),
+      url: normalize_image_url(Map.fetch!(attrs, "url"), config),
       medium: %{
-        url: attrs["medium"]["url"]
+        url: normalize_image_url(attrs["medium"]["url"], config)
       },
       small: %{
-        url: attrs["small"]["url"]
+        url: normalize_image_url(attrs["small"]["url"], config)
       },
       thumb: %{
-        url: attrs["thumb"]["url"]
+        url: normalize_image_url(attrs["thumb"]["url"], config)
       }
     }
+  end
+
+  defp normalize_image_url(nil, _), do: nil
+
+  defp normalize_image_url(url, configuration) do
+    config = Configuration.build(configuration)
+
+    case URI.parse(url) do
+      %URI{host: nil, path: path, query: query} ->
+        config[:api_url]
+        |> URI.parse()
+        |> Map.merge(%{path: path, query: query})
+        |> URI.to_string()
+
+      _ ->
+        url
+    end
   end
 end

--- a/lib/members/member.ex
+++ b/lib/members/member.ex
@@ -34,8 +34,8 @@ defmodule GlassFactoryApi.Members.Member do
         joined_at: "2019-01-01"
       }
   """
-  @spec to_struct(map()) :: __MODULE__.t()
-  def to_struct(attrs) do
+  @spec to_struct(map(), map()) :: __MODULE__.t()
+  def to_struct(attrs, config) do
     %__MODULE__{
       name: attrs["name"],
       id: attrs["id"],
@@ -44,7 +44,7 @@ defmodule GlassFactoryApi.Members.Member do
       capacity: attrs["capacity"],
       freelancer: attrs["freelancer"],
       joined_at: attrs["joined_at"],
-      avatar: Avatar.to_struct(attrs["avatar"])
+      avatar: Avatar.to_struct(attrs["avatar"], config)
     }
   end
 end

--- a/lib/members/member.ex
+++ b/lib/members/member.ex
@@ -1,4 +1,6 @@
 defmodule GlassFactoryApi.Members.Member do
+  alias GlassFactoryApi.Members.Avatar
+
   @moduledoc """
   Defines the Member of organization.
   """
@@ -10,10 +12,11 @@ defmodule GlassFactoryApi.Members.Member do
           archived: boolean(),
           capacity: non_neg_integer(),
           freelancer: boolean(),
-          joined_at: String.t()
+          joined_at: String.t(),
+          avatar: Avatar.t()
         }
 
-  defstruct [:name, :email, :id, :archived, :capacity, :freelancer, :joined_at]
+  defstruct [:name, :email, :id, :archived, :capacity, :freelancer, :joined_at, :avatar]
 
   @doc """
   Parse a map into a Member struct
@@ -40,7 +43,8 @@ defmodule GlassFactoryApi.Members.Member do
       archived: attrs["archived"],
       capacity: attrs["capacity"],
       freelancer: attrs["freelancer"],
-      joined_at: attrs["joined_at"]
+      joined_at: attrs["joined_at"],
+      avatar: Avatar.to_struct(attrs["avatar"])
     }
   end
 end

--- a/test/members/avatar_test.exs
+++ b/test/members/avatar_test.exs
@@ -5,7 +5,12 @@ defmodule GlassFactoryApi.Members.AvatarTest do
 
   describe "to_struct/1" do
     test "returns an avatar struct" do
-      config = %{api_url: "http://example.org/"}
+      config = %{
+        api_url: "http://example.org/",
+        subdomain: "example",
+        user_token: "test_user_token",
+        user_email: "foo@example.org"
+      }
 
       data_map = %{
         "url" => "http://example.org/user/1/avatar.jpeg",
@@ -23,7 +28,12 @@ defmodule GlassFactoryApi.Members.AvatarTest do
     end
 
     test "when the api does not send a full URL it normalizes it" do
-      config = %{api_url: "http://example.org/"}
+      config = %{
+        api_url: "http://example.org/",
+        subdomain: "example",
+        user_token: "test_user_token",
+        user_email: "foo@example.org"
+      }
 
       data_map = %{
         "url" => "/user/1/avatar.jpeg",

--- a/test/members/avatar_test.exs
+++ b/test/members/avatar_test.exs
@@ -5,6 +5,8 @@ defmodule GlassFactoryApi.Members.AvatarTest do
 
   describe "to_struct/1" do
     test "returns an avatar struct" do
+      config = %{api_url: "http://example.org/"}
+
       data_map = %{
         "url" => "http://example.org/user/1/avatar.jpeg",
         "medium" => %{"url" => "http://example.org/user/1/avatar_medium.jpeg"},
@@ -17,7 +19,25 @@ defmodule GlassFactoryApi.Members.AvatarTest do
                medium: %{url: "http://example.org/user/1/avatar_medium.jpeg"},
                small: %{url: "http://example.org/user/1/avatar_small.jpeg"},
                thumb: %{url: "http://example.org/user/1/avatar_thumb.jpeg"}
-             } = Avatar.to_struct(data_map)
+             } = Avatar.to_struct(data_map, config)
+    end
+
+    test "when the api does not send a full URL it normalizes it" do
+      config = %{api_url: "http://example.org/"}
+
+      data_map = %{
+        "url" => "/user/1/avatar.jpeg",
+        "medium" => %{"url" => "/user/1/avatar_medium.jpeg"},
+        "small" => %{"url" => "/user/1/avatar_small.jpeg"},
+        "thumb" => %{"url" => "/user/1/avatar_thumb.jpeg"}
+      }
+
+      assert %Avatar{
+               url: "http://example.org/user/1/avatar.jpeg",
+               medium: %{url: "http://example.org/user/1/avatar_medium.jpeg"},
+               small: %{url: "http://example.org/user/1/avatar_small.jpeg"},
+               thumb: %{url: "http://example.org/user/1/avatar_thumb.jpeg"}
+             } = Avatar.to_struct(data_map, config)
     end
   end
 end

--- a/test/members/avatar_test.exs
+++ b/test/members/avatar_test.exs
@@ -1,0 +1,23 @@
+defmodule GlassFactoryApi.Members.AvatarTest do
+  use ExUnit.Case, async: false
+
+  alias GlassFactoryApi.Members.Avatar
+
+  describe "to_struct/1" do
+    test "returns an avatar struct" do
+      data_map = %{
+        "url" => "http://example.org/user/1/avatar.jpeg",
+        "medium" => %{"url" => "http://example.org/user/1/avatar_medium.jpeg"},
+        "small" => %{"url" => "http://example.org/user/1/avatar_small.jpeg"},
+        "thumb" => %{"url" => "http://example.org/user/1/avatar_thumb.jpeg"}
+      }
+
+      assert %Avatar{
+               url: "http://example.org/user/1/avatar.jpeg",
+               medium: %{url: "http://example.org/user/1/avatar_medium.jpeg"},
+               small: %{url: "http://example.org/user/1/avatar_small.jpeg"},
+               thumb: %{url: "http://example.org/user/1/avatar_thumb.jpeg"}
+             } = Avatar.to_struct(data_map)
+    end
+  end
+end

--- a/test/members/member_test.exs
+++ b/test/members/member_test.exs
@@ -6,7 +6,12 @@ defmodule GlassFactoryApi.Members.MemberTest do
 
   describe "to_struct/1" do
     test "parses a map to a Member struct" do
-      config = %{api_url: "http://example.org/"}
+      config = %{
+        api_url: "http://example.org/",
+        subdomain: "example",
+        user_token: "test_user_token",
+        user_email: "foo@example.org"
+      }
 
       data_map = %{
         "name" => "John Doe",

--- a/test/members/member_test.exs
+++ b/test/members/member_test.exs
@@ -1,16 +1,25 @@
 defmodule GlassFactoryApi.Members.MemberTest do
   use ExUnit.Case, async: true
 
+  alias GlassFactoryApi.Members.Avatar
   alias GlassFactoryApi.Members.Member
 
   describe "to_struct/1" do
     test "parses a map to a Member struct" do
-      data_map = %{"name" => "John Doe", "id" => 10, "email" => "john.doe@example.org"}
+      data_map = %{
+        "name" => "John Doe",
+        "id" => 10,
+        "email" => "john.doe@example.org",
+        "avatar" => %{"url" => "/default_user/avatar/2632.svg"}
+      }
 
       assert %Member{
                name: "John Doe",
                id: 10,
-               email: "john.doe@example.org"
+               email: "john.doe@example.org",
+               avatar: %Avatar{
+                 url: "/default_user/avatar/2632.svg"
+               }
              } = Member.to_struct(data_map)
     end
   end

--- a/test/members/member_test.exs
+++ b/test/members/member_test.exs
@@ -6,6 +6,8 @@ defmodule GlassFactoryApi.Members.MemberTest do
 
   describe "to_struct/1" do
     test "parses a map to a Member struct" do
+      config = %{api_url: "http://example.org/"}
+
       data_map = %{
         "name" => "John Doe",
         "id" => 10,
@@ -18,9 +20,9 @@ defmodule GlassFactoryApi.Members.MemberTest do
                id: 10,
                email: "john.doe@example.org",
                avatar: %Avatar{
-                 url: "/default_user/avatar/2632.svg"
+                 url: "http://example.org/default_user/avatar/2632.svg"
                }
-             } = Member.to_struct(data_map)
+             } = Member.to_struct(data_map, config)
     end
   end
 end

--- a/test/members_test.exs
+++ b/test/members_test.exs
@@ -173,7 +173,13 @@ defmodule GlassFactoryApi.MembersTest do
                   capacity: 8.0,
                   email: "john.doe@example.org",
                   freelancer: false,
-                  joined_at: "2019-01-01"
+                  joined_at: "2019-01-01",
+                  avatar: %Avatar{
+                    url: "/default_avatar/user/2666.svg",
+                    medium: %{url: "/default_avatar/user/2666.svg"},
+                    small: %{url: "/default_avatar/user/2666.svg"},
+                    thumb: %{url: "/default_avatar/user/2666.svg"}
+                  }
                 }
               ]} == Members.list_active_members(config)
     end
@@ -197,7 +203,13 @@ defmodule GlassFactoryApi.MembersTest do
                  capacity: 8.0,
                  email: "john.doe@example.org",
                  freelancer: false,
-                 joined_at: "2019-01-01"
+                 joined_at: "2019-01-01",
+                 avatar: %Avatar{
+                   url: "/default_avatar/user/2666.svg",
+                   medium: %{url: "/default_avatar/user/2666.svg"},
+                   small: %{url: "/default_avatar/user/2666.svg"},
+                   thumb: %{url: "/default_avatar/user/2666.svg"}
+                 }
                }
              ] == Members.list_active_members!(config)
     end

--- a/test/members_test.exs
+++ b/test/members_test.exs
@@ -39,10 +39,10 @@ defmodule GlassFactoryApi.MembersTest do
                   freelancer: false,
                   joined_at: "2019-01-01",
                   avatar: %Avatar{
-                    url: "/default_avatar/user/2666.svg",
-                    medium: %{url: "/default_avatar/user/2666.svg"},
-                    small: %{url: "/default_avatar/user/2666.svg"},
-                    thumb: %{url: "/default_avatar/user/2666.svg"}
+                    url: "#{config[:api_url]}/default_avatar/user/2666.svg",
+                    medium: %{url: "#{config[:api_url]}/default_avatar/user/2666.svg"},
+                    small: %{url: "#{config[:api_url]}/default_avatar/user/2666.svg"},
+                    thumb: %{url: "#{config[:api_url]}/default_avatar/user/2666.svg"}
                   }
                 }
               ]} == Members.list_members(config)
@@ -69,10 +69,10 @@ defmodule GlassFactoryApi.MembersTest do
                  freelancer: false,
                  joined_at: "2019-01-01",
                  avatar: %Avatar{
-                   url: "/default_avatar/user/2666.svg",
-                   medium: %{url: "/default_avatar/user/2666.svg"},
-                   small: %{url: "/default_avatar/user/2666.svg"},
-                   thumb: %{url: "/default_avatar/user/2666.svg"}
+                   url: "#{config[:api_url]}/default_avatar/user/2666.svg",
+                   medium: %{url: "#{config[:api_url]}/default_avatar/user/2666.svg"},
+                   small: %{url: "#{config[:api_url]}/default_avatar/user/2666.svg"},
+                   thumb: %{url: "#{config[:api_url]}/default_avatar/user/2666.svg"}
                  }
                }
              ] == Members.list_members!(config)
@@ -99,12 +99,12 @@ defmodule GlassFactoryApi.MembersTest do
                 freelancer: false,
                 joined_at: "2019-01-01",
                 avatar: %Avatar{
-                  url: "/default_avatar/user/2666.svg",
-                  medium: %{url: "/default_avatar/user/2666.svg"},
-                  small: %{url: "/default_avatar/user/2666.svg"},
-                  thumb: %{url: "/default_avatar/user/2666.svg"}
+                  url: "#{config[:api_url]}/default_avatar/user/2666.svg",
+                  medium: %{url: "#{config[:api_url]}/default_avatar/user/2666.svg"},
+                  small: %{url: "#{config[:api_url]}/default_avatar/user/2666.svg"},
+                  thumb: %{url: "#{config[:api_url]}/default_avatar/user/2666.svg"}
                 }
-              }} = Members.get_member(2666, config)
+              }} == Members.get_member(2666, config)
     end
 
     test "returns nil when the id does not exist", %{bypass: bypass, config: config} do
@@ -135,12 +135,12 @@ defmodule GlassFactoryApi.MembersTest do
                freelancer: false,
                joined_at: "2019-01-01",
                avatar: %Avatar{
-                 url: "/default_avatar/user/2666.svg",
-                 medium: %{url: "/default_avatar/user/2666.svg"},
-                 small: %{url: "/default_avatar/user/2666.svg"},
-                 thumb: %{url: "/default_avatar/user/2666.svg"}
+                 url: "#{config[:api_url]}/default_avatar/user/2666.svg",
+                 medium: %{url: "#{config[:api_url]}/default_avatar/user/2666.svg"},
+                 small: %{url: "#{config[:api_url]}/default_avatar/user/2666.svg"},
+                 thumb: %{url: "#{config[:api_url]}/default_avatar/user/2666.svg"}
                }
-             } = Members.get_member!(2666, config)
+             } == Members.get_member!(2666, config)
     end
 
     test "returns nil when the id does not exist", %{bypass: bypass, config: config} do
@@ -175,10 +175,10 @@ defmodule GlassFactoryApi.MembersTest do
                   freelancer: false,
                   joined_at: "2019-01-01",
                   avatar: %Avatar{
-                    url: "/default_avatar/user/2666.svg",
-                    medium: %{url: "/default_avatar/user/2666.svg"},
-                    small: %{url: "/default_avatar/user/2666.svg"},
-                    thumb: %{url: "/default_avatar/user/2666.svg"}
+                    url: "#{config[:api_url]}/default_avatar/user/2666.svg",
+                    medium: %{url: "#{config[:api_url]}/default_avatar/user/2666.svg"},
+                    small: %{url: "#{config[:api_url]}/default_avatar/user/2666.svg"},
+                    thumb: %{url: "#{config[:api_url]}/default_avatar/user/2666.svg"}
                   }
                 }
               ]} == Members.list_active_members(config)
@@ -205,10 +205,10 @@ defmodule GlassFactoryApi.MembersTest do
                  freelancer: false,
                  joined_at: "2019-01-01",
                  avatar: %Avatar{
-                   url: "/default_avatar/user/2666.svg",
-                   medium: %{url: "/default_avatar/user/2666.svg"},
-                   small: %{url: "/default_avatar/user/2666.svg"},
-                   thumb: %{url: "/default_avatar/user/2666.svg"}
+                   url: "#{config[:api_url]}/default_avatar/user/2666.svg",
+                   medium: %{url: "#{config[:api_url]}/default_avatar/user/2666.svg"},
+                   small: %{url: "#{config[:api_url]}/default_avatar/user/2666.svg"},
+                   thumb: %{url: "#{config[:api_url]}/default_avatar/user/2666.svg"}
                  }
                }
              ] == Members.list_active_members!(config)

--- a/test/members_test.exs
+++ b/test/members_test.exs
@@ -2,6 +2,7 @@ defmodule GlassFactoryApi.MembersTest do
   use ExUnit.Case, async: true
 
   alias GlassFactoryApi.Members
+  alias GlassFactoryApi.Members.Avatar
   alias GlassFactoryApi.Members.Member
 
   setup do
@@ -36,7 +37,13 @@ defmodule GlassFactoryApi.MembersTest do
                   capacity: 8.0,
                   email: "john.doe@example.org",
                   freelancer: false,
-                  joined_at: "2019-01-01"
+                  joined_at: "2019-01-01",
+                  avatar: %Avatar{
+                    url: "/default_avatar/user/2666.svg",
+                    medium: %{url: "/default_avatar/user/2666.svg"},
+                    small: %{url: "/default_avatar/user/2666.svg"},
+                    thumb: %{url: "/default_avatar/user/2666.svg"}
+                  }
                 }
               ]} == Members.list_members(config)
     end
@@ -60,7 +67,13 @@ defmodule GlassFactoryApi.MembersTest do
                  capacity: 8.0,
                  email: "john.doe@example.org",
                  freelancer: false,
-                 joined_at: "2019-01-01"
+                 joined_at: "2019-01-01",
+                 avatar: %Avatar{
+                   url: "/default_avatar/user/2666.svg",
+                   medium: %{url: "/default_avatar/user/2666.svg"},
+                   small: %{url: "/default_avatar/user/2666.svg"},
+                   thumb: %{url: "/default_avatar/user/2666.svg"}
+                 }
                }
              ] == Members.list_members!(config)
     end
@@ -84,7 +97,13 @@ defmodule GlassFactoryApi.MembersTest do
                 capacity: 8.0,
                 email: "john.doe@example.org",
                 freelancer: false,
-                joined_at: "2019-01-01"
+                joined_at: "2019-01-01",
+                avatar: %Avatar{
+                  url: "/default_avatar/user/2666.svg",
+                  medium: %{url: "/default_avatar/user/2666.svg"},
+                  small: %{url: "/default_avatar/user/2666.svg"},
+                  thumb: %{url: "/default_avatar/user/2666.svg"}
+                }
               }} = Members.get_member(2666, config)
     end
 
@@ -114,7 +133,13 @@ defmodule GlassFactoryApi.MembersTest do
                capacity: 8.0,
                email: "john.doe@example.org",
                freelancer: false,
-               joined_at: "2019-01-01"
+               joined_at: "2019-01-01",
+               avatar: %Avatar{
+                 url: "/default_avatar/user/2666.svg",
+                 medium: %{url: "/default_avatar/user/2666.svg"},
+                 small: %{url: "/default_avatar/user/2666.svg"},
+                 thumb: %{url: "/default_avatar/user/2666.svg"}
+               }
              } = Members.get_member!(2666, config)
     end
 


### PR DESCRIPTION
### Motivation 

The GlassFactoryApi returns the avatar URL of the Member and we should map it in our Member struct. 


### Proposed Solution

Add an Avatar struct that defines an Avatar since it already has a few maps inside, for now, I'm just mapping the fields as they are from GlassFactory, maybe in future, we can change it to a better structure. 


### Caveat 

I'm creating something that might be tricky here and it needs to be well documented (I'm working on the docs right now). 

When a Member changes his avatar GlassFactory uploads it to an S3 bucket and provides a full URL to the image (something like: `http://s3-bucket.amazonaws.com/avatars/user_id/avatar.jpg` but when the Member didn't change the avatar yet, it provides a default URL like `/default_avatar/user/user_id.svg` without protocol and domain information which I figure out that must be the same value provided in `GLASSFACTORY_API_URL` env var used in this lib configuration. 

I think it would be very tricky to handle in the library, I need to verify if a URL contains the protocol and domain information and them figure out a way to access the config variables and transform the URL string, the way I'm suggesting now I'm letting the client handle it, I'm just passing what GlassFactory returns. 

Please leave your thoughts about it! Share some ❤️

cc/ @britto 

### Tasks

- [x]  Add Avatar struct
- [x] Add Avatar property to Member
- [ ] Docs  📚 